### PR TITLE
Amendments for September 2025 SGM

### DIFF
--- a/Constitution.md
+++ b/Constitution.md
@@ -38,13 +38,12 @@ To do all such things as would appear necessary and proper for the benefit or ad
 
 3.6 Any member may leave the club or resign from a particular post they hold, at any time, by providing written notice to the secretary.
 
-**6. HONORARY LIFE MEMBERS**
+**4. HONORARY LIFE MEMBERS**
+4.1 The Club may in General Meeting by two-thirds majority of those present and voting confer Honorary Life Membership upon any member who has performed outstanding service to the Club. Honorary Life Members are given the rights and privileges of an Associate of the Club, unless otherwise eligible to be an Ordinary Member.
 
-6.1 The Club may in General Meeting by two-thirds majority of those present and voting confer Honorary Life Membership upon any member who has performed outstanding service to the Club. Honorary Life Members are given the rights and privileges of an Associate of the Club, unless otherwise eligible to be an Ordinary Member.
+**5. PRIMACY OF ORDINARY MEMBERS**
 
-**7. PRIMACY OF ORDINARY MEMBERS**
-
-7.1 Only Members that are Ordinary Members shall:
+5.1 Only Members that are Ordinary Members shall:
 
 Be voting members of the Club.
 
@@ -52,29 +51,29 @@ Nominate candidates for the offices and Committee of the Club.
 
 Become or remain office bearers of the Club.
 
-**8. MEETING OF THE CLUB**
+**6. MEETING OF THE CLUB**
 
-8.1 The Club shall hold its Annual General Meeting in March of each academic year.
+6.1 The Club shall hold its Annual General Meeting in March of each academic year.
 
-8.1.1 The Club will hold its inaugural Annual General Meeting in August.
+6.1.1 The Club will hold its inaugural Annual General Meeting in August.
 
-8.2 The Committee may at any time call a Special General Meeting of the Club.
+6.2 The Committee may at any time call a Special General Meeting of the Club.
 
-8.3 The Secretary shall forthwith call a Special General Meeting upon receiving a written requisition from at least 10 financial ordinary members of the Club, and such a meeting shall be held no later than ten days immediately following receipt of such a requisition.
+6.3 The Secretary shall forthwith call a Special General Meeting upon receiving a written requisition from at least 10 financial ordinary members of the Club, and such a meeting shall be held no later than ten days immediately following receipt of such a requisition.
 
-8.4 If the Secretary fails to call the meeting within that time, any of the signatories of the requisition may do so. Any business set out in the requisition shall have priority over all the other business.
+6.4 If the Secretary fails to call the meeting within that time, any of the signatories of the requisition may do so. Any business set out in the requisition shall have priority over all the other business.
 
-**9. PROVISIONS GOVERNING GENERAL MEETINGS**
+**7. PROVISIONS GOVERNING GENERAL MEETINGS**
 
-9.1 The Secretary shall cause written notice of any General Meeting to be posted on the Guild notice boards, or in Guild mailing services, at least seven days before the date appointed for that meeting.
+7.1 The Secretary shall cause written notice of any General Meeting to be posted on the Guild notice boards, or in Guild mailing services, at least seven days before the date appointed for that meeting.
 
-9.2 No General Meeting may be held while a Guild General Meeting is in progress. This shall not apply where written notice of the meeting was given before written notice of the Guild General Meeting. Any such meeting being conducted in contravention thereof shall disband immediately on the order of disciplinary officer of the Guild.
+7.2 No General Meeting may be held while a Guild General Meeting is in progress. This shall not apply where written notice of the meeting was given before written notice of the Guild General Meeting. Any such meeting being conducted in contravention thereof shall disband immediately on the order of disciplinary officer of the Guild.
 
-9.3 The quorum of General Meeting shall consist of 10 Financial Ordinary Membership for the time being.
+7.3 The quorum of General Meeting shall consist of 10 Financial Ordinary Membership for the time being.
 
-9.4 All General Meeting of the Club shall be conducted in accordance with the procedure prescribed in the Standing Rules and Orders of the Guild Council.
+7.4 All General Meeting of the Club shall be conducted in accordance with the procedure prescribed in the Standing Rules and Orders of the Guild Council.
 
-9.5 Any General Meetings of the club involving an election must be supervised by at least one Returning Officer who shall:
+7.5 Any General Meetings of the club involving an election must be supervised by at least one Returning Officer who shall:
 
 (a) Not be contesting the election
 
@@ -82,13 +81,13 @@ Become or remain office bearers of the Club.
 
 (c) Be confirmed by the members at the General Meeting before conducting the election
 
-**10. PATRON**
+**8. PATRON**
 
-10.1 The Club may, at the Annual General Meeting, elect a patron who shall, if they indicate their willingness to do so, hold office until the succeeding Annual General Meeting; nominations shall close at that meeting.
+8.1 The Club may, at the Annual General Meeting, elect a patron who shall, if they indicate their willingness to do so, hold office until the succeeding Annual General Meeting; nominations shall close at that meeting.
 
-**12. EXECUTIVE OFFICE BEARERS**
+**9. EXECUTIVE OFFICE BEARERS**
 
-12.1 The Executive Office Bearers of the Club shall consist of, in order of seniority:
+9.1 The Executive Office Bearers of the Club shall consist of, in order of seniority:
 
 The President
 
@@ -100,9 +99,9 @@ The Secretary
 
 The Treasurer
 
-12.2 No Executive Office Bearer may hold an Executive position simultaneously within the club or with another University of WA Club. In the event it does happen, The Executive Office Bearer must step down from their Executive Position in any of Clubs.
+9.2 No Executive Office Bearer may hold an Executive position simultaneously within the club or with another University of WA Club. In the event it does happen, The Executive Office Bearer must step down from their Executive Position in any of Clubs.
 
-12.3 The Committee in meeting may dismiss an Elected Office-Bearer where, in the opinion of three quarters of the members of the Committee present and voting, that Elected Office-Bearer has:
+9.3 The Committee in meeting may dismiss an Elected Office-Bearer where, in the opinion of three quarters of the members of the Committee present and voting, that Elected Office-Bearer has:
 
 (a) Consistently failed adequately to discharge the duties of that position; or
 
@@ -112,9 +111,9 @@ The Treasurer
 
 (d) Been accorded the opportunity to be present and to speak at that Committee Meeting.
 
-**13. THE COMMITTEE**
+**10. THE COMMITTEE**
 
-13.1 The Committee of the Club shall only consist of:
+10.1 The Committee of the Club shall only consist of:
 
 1. The President
 
@@ -134,13 +133,13 @@ The Treasurer
 
 9. The Immediate Past President.
 
-13.2 Only the person who held the Elected Office Bearer position of President immediately preceding the commencement of the current President‘s term shall be appointed Immediate Past President.
+10.2 Only the person who held the Elected Office Bearer position of President immediately preceding the commencement of the current President‘s term shall be appointed Immediate Past President.
 
-**. ELECTION**
+**11. ELECTION**
 
-14.1 The Club shall hold its Annual General Meeting in March of each academic year.
+11.1 The Club shall hold its Annual General Meeting in March of each academic year.
 
-14.2 The following members of the Committee shall be elected at the Annual General Meeting:
+11.2 The following members of the Committee shall be elected at the Annual General Meeting:
 
 1. The President
 
@@ -158,73 +157,73 @@ The Treasurer
 
 8. The Fresher Representative
 
-14.3 The Secretary shall call for nominations for the above positions at least seven days before the date of the Annual General Meeting. The nominations shall close at that meeting.
+11.3 The Secretary shall call for nominations for the above positions at least seven days before the date of the Annual General Meeting. The nominations shall close at that meeting.
 
-14.4 Any Ordinary Member of the Club may vote for the positions of Committee members.
+11.4 Any Ordinary Member of the Club may vote for the positions of Committee members.
 
-14.5 Only Ordinary Members of the Club who are students at The University of Western Australia and members of the Student Guild of The University of Western Australia may hold positions on the Committee.
+11.5 Only Ordinary Members of the Club who are students at The University of Western Australia and members of the Student Guild of The University of Western Australia may hold positions on the Committee.
 
-14.6 Members may be elected to and hold at most one position on the Committee.
+11.6 Members may be elected to and hold at most one position on the Committee.
 
-14.7 The committee may choose to hold an Ordinary General Meeting in the second academic semester.
+11.7 The committee may choose to hold an Ordinary General Meeting in the second academic semester.
 
-14.7.1 At this Ordinary General Meeting, the committee may hold an election for up to two additional Ordinary Committee Members
+11.7.1 At this Ordinary General Meeting, the committee may hold an election for up to two additional Ordinary Committee Members
 
-14.7.2 The decision to hold such an election will be decided by, and announced by, the committee, at least ten days before the date of the Ordinary General Meeting.
+11.7.2 The decision to hold such an election will be decided by, and announced by, the committee, at least ten days before the date of the Ordinary General Meeting.
 
-**15. DURATION OF OFFICE**
+**12. DURATION OF OFFICE**
 
-15.1 The Executive Office Bearers and the Ordinary Committee members shall remain in office until the next Annual General Meeting.
+12.1 The Executive Office Bearers and the Ordinary Committee members shall remain in office until the next Annual General Meeting.
 
-15.2 If an Ordinary Committee Member fails to arrive to a meeting without a valid reason, they shall gain a strike. If the same member gains three strikes, they shall be removed from the position.
+12.2 If an Ordinary Committee Member fails to arrive to a meeting without a valid reason, they shall gain a strike. If the same member gains three strikes, they shall be removed from the position.
 
-15.3 If an Ordinary Committee Member fails to fulfil their role, they shall be subject to the same rules as that of an Executive Office Bearer outlined in Article 12.8 of this Constitution.
+12.3 If an Ordinary Committee Member fails to fulfil their role, they shall be subject to the same rules as that of an Executive Office Bearer outlined in Article 12.8 of this Constitution.
 
-**16. VACANCIES**
+**13. VACANCIES**
 
-16.1 If an Office Bearer resigns or ceases to hold office for any reason the remaining members of the Committee shall forthwith fill the vacancy so created by appointing thereto a member of the Committee from the Ordinary Membership, subject to review at the next General Meeting.
+13.1 If an Office Bearer resigns or ceases to hold office for any reason the remaining members of the Committee shall forthwith fill the vacancy so created by appointing thereto a member of the Committee from the Ordinary Membership, subject to review at the next General Meeting.
 
-16.2 The committee shall therefore have the power to appoint a financial member of the club as an interim Ordinary Committee Member to fill the vacancy.
+13.2 The committee shall therefore have the power to appoint a financial member of the club as an interim Ordinary Committee Member to fill the vacancy.
 
-16.3 Newly appointed Office Bearers will be ratified at the next General Meeting of the club, which shall be held no later than 2 months after the appointment/s.
+13.3 Newly appointed Office Bearers will be ratified at the next General Meeting of the club, which shall be held no later than 2 months after the appointment/s.
 
-**17. COMMITTEE MEETINGS**
+**14. COMMITTEE MEETINGS**
 
-17.1 The Committee shall meet at such times and places as the President shall determine.
+14.1 The Committee shall meet at such times and places as the President shall determine.
 
-17.2 The Secretary shall cause all members of the Committee to receive seven days’ notice before the date fixed for the meeting together with an agenda of the business to be discussed.
+14.2 The Secretary shall cause all members of the Committee to receive seven days’ notice before the date fixed for the meeting together with an agenda of the business to be discussed.
 
-17.3 The Secretary shall forthwith call a Special General Meeting of the Committee upon receiving a written requisition from at least two members thereof, and such a Special General Meeting shall be held not later than seven days immediately following receipt of requisition.
+14.3 The Secretary shall forthwith call a Special General Meeting of the Committee upon receiving a written requisition from at least two members thereof, and such a Special General Meeting shall be held not later than seven days immediately following receipt of requisition.
 
-17.4 If the Secretary fails to call the meeting within that time, any one of the members signing the requisition may do so. Any business set out in the requisition shall have priority over all other business.
+14.4 If the Secretary fails to call the meeting within that time, any one of the members signing the requisition may do so. Any business set out in the requisition shall have priority over all other business.
 
-**18. QUORUM AND PROCEDURE OF COMMITTEE**
+**15. QUORUM AND PROCEDURE OF COMMITTEE**
 
-18.1 The quorum of the Committee shall be 5 of whom at least two shall be Office Bearers.
+15.1 The quorum of the Committee shall be 5 of whom at least two shall be Office Bearers.
 
-18.2 All meetings of the Committee shall be conducted in accordance with the procedure prescribed in the Standing Rules and Orders of the Guild Council.
+15.2 All meetings of the Committee shall be conducted in accordance with the procedure prescribed in the Standing Rules and Orders of the Guild Council.
 
-**19. POWER OF COMMITTEE**
+**16. POWER OF COMMITTEE**
 
 Subject to this Constitution, the Committee shall be responsible to the Club in General Meeting for giving effect to the Objectives of the Club as set out in Article 2 and elsewhere in this Constitution and for carrying on its everyday business, and without prejudice to the generality of the foregoing, have the power to:
 
-19.1 Acquire and dispose of property; dispose of monies; open banking accounts; and enter into contracts. Unless acting under a special enabling resolution of General Meeting, however, the Committee shall not borrow or raise money or incur debts or liabilities on behalf of or in the name of the Club to a greater amount than five dollars for each and every then existing financial Ordinary Member of the Club.
+16.1 Acquire and dispose of property; dispose of monies; open banking accounts; and enter into contracts. Unless acting under a special enabling resolution of General Meeting, however, the Committee shall not borrow or raise money or incur debts or liabilities on behalf of or in the name of the Club to a greater amount than five dollars for each and every then existing financial Ordinary Member of the Club.
 
-19.2 Make regulations for the orderly and proper management of the affairs of the Club, ensuring that no regulation is inconsistent or repugnant with this Constitution.
+16.2 Make regulations for the orderly and proper management of the affairs of the Club, ensuring that no regulation is inconsistent or repugnant with this Constitution.
 
-19.3 Make, alter or repeal By-Laws and impose fines for the breach therefore. All By-Laws and any alterations or amendment therefore shall be subject to ratification by Societies Council and Guild Council before coming into force. The maximum fine imposed may not exceed five dollars.
+16.3 Make, alter or repeal By-Laws and impose fines for the breach therefore. All By-Laws and any alterations or amendment therefore shall be subject to ratification by Societies Council and Guild Council before coming into force. The maximum fine imposed may not exceed five dollars.
 
-**20. CHAIR**
+**17. CHAIR**
 
-20.1 The President shall have the right to take the Chair at any meeting of the Club or of the Committee.
+17.1 The President shall have the right to take the Chair at any meeting of the Club or of the Committee.
 
-20.2 If the President is absent or does not wish to exercise his right at any meeting, that right shall develop upon the Vice President.
+17.2 If the President is absent or does not wish to exercise his right at any meeting, that right shall develop upon the Vice President.
 
-20.3 In the event of absence of both the President and the Vice President, or in event of them both not wishing to exercise their right, that meeting shall elect its own Chair.
+17.3 In the event of absence of both the President and the Vice President, or in event of them both not wishing to exercise their right, that meeting shall elect its own Chair.
 
-**21. PRESIDENT**
+**18. PRESIDENT**
 
-21.1 In addition to any provisions set out elsewhere in this Constitution or in any By-Laws or Regulations made hereunder, it shall be the duty of the President to:
+18.1 In addition to any provisions set out elsewhere in this Constitution or in any By-Laws or Regulations made hereunder, it shall be the duty of the President to:
 
 (a) Coordinate and supervise the work of the Executive Office Bearers, subject to the authority of the Club in General Meeting.
 
@@ -234,17 +233,17 @@ Subject to this Constitution, the Committee shall be responsible to the Club in 
 
 (d) Report on the status of the club to the ordinary members at all general meetings.
 
-**22. VICE PRESIDENT**
+**19. VICE PRESIDENT**
 
-22.1 In addition to any provisions set out elsewhere in the Constitution or in any By-Laws or Regulations made hereunder, it shall be the duty of the Vice President to:
+19.1 In addition to any provisions set out elsewhere in the Constitution or in any By-Laws or Regulations made hereunder, it shall be the duty of the Vice President to:
 
 (a) Seek, engage and maintain client relationships, as well as source projects, and oversee their delivery.
 
 (b) assist the President wherever possible.
 
-**23. TECHNICAL LEAD**
+**20. TECHNICAL LEAD**
 
-23.1 In addition to any provisions set out elsewhere in the Constitution or in any By-Laws or Regulations made hereunder, it shall be the duty of the Technical Lead:
+20.1 In addition to any provisions set out elsewhere in the Constitution or in any By-Laws or Regulations made hereunder, it shall be the duty of the Technical Lead:
 
 (a) To advise the Committee on technical and development related matters.
 
@@ -252,9 +251,9 @@ Subject to this Constitution, the Committee shall be responsible to the Club in 
 
 (c) To conduct code reviews and assist with project development if requested.
 
-**24. SECRETARY**
+**21. SECRETARY**
 
-24.1 In addition to any provisions set out elsewhere in the Constitution or in any By-Laws or Regulations made hereunder, it shall be the duty of the Secretary:
+21.1 In addition to any provisions set out elsewhere in the Constitution or in any By-Laws or Regulations made hereunder, it shall be the duty of the Secretary:
 
 (a) To record all proceedings of the Club and the Committee in a Club Minute Book which they shall cause to be provided for that purpose:
 
@@ -272,9 +271,9 @@ To lodge with the Secretary of the Societies Council a copy of the Constitution 
 
 (e) In the event of the Club being de-registered, to present to the Societies Council Secretary within thirty days a duly audited statement of the financial position of the Club together with a copy of the resolution, which may have been passed by the Club as to the disposition of its funds.
 
-**25. TREASURER**
+**22. TREASURER**
 
-25.1 In addition to any provisions set out elsewhere in the Constitution or in any By-Laws or Regulations made hereunder, it shall be the duty of the Treasurer:
+22.1 In addition to any provisions set out elsewhere in the Constitution or in any By-Laws or Regulations made hereunder, it shall be the duty of the Treasurer:
 
 Keep proper books of account dealing with the property and finances of the Club and to furnish the Committee with such accounts and information relating to the finances and property of the Club as the Committee from time to time require.
 
@@ -286,52 +285,52 @@ Produce and deliver all necessary books, vouchers and other documents to the per
 
 Prepare necessary forms, and receipts for Societies Council in accordance with Societies Council grant policies.
 
-**26. DEPOSITS AND WITHDRAWAL OF MONIES**
+**23. DEPOSITS AND WITHDRAWAL OF MONIES**
 
-26.1 All monies due and payable to the Club shall be received by the Treasurer who shall lodge them without undue delay with Guild Finance for the credit of the Club.
+23.1 All monies due and payable to the Club shall be received by the Treasurer who shall lodge them without undue delay with Guild Finance for the credit of the Club.
 
-26.2 Any two members of the Executive may jointly sign cheques and forms of authority for the payment of funds of the Society.
+23.2 Any two members of the Executive may jointly sign cheques and forms of authority for the payment of funds of the Society.
 
-26.3 Notwithstanding anything contained herein, no persons shall deposit or withdraw any monies into any account that Guild Council has closed by resolution.
+23.3 Notwithstanding anything contained herein, no persons shall deposit or withdraw any monies into any account that Guild Council has closed by resolution.
 
-**27. PAYMENTS**
+**24. PAYMENTS**
 
-27.1 No payments shall be made on behalf or in the name of the Club unless it has been authorised by the Executive Office Bearers, in accordance with Article 2.2
+24.1 No payments shall be made on behalf or in the name of the Club unless it has been authorised by the Executive Office Bearers, in accordance with Article 2.2
 
-**28. MAJOR OBLIGATIONS TO GUILD**
+**25. MAJOR OBLIGATIONS TO GUILD**
 
-28.1 The Club shall comply with the Regulation of the Guild, the Rules of the Societies Council, and all other provisions enrolled upon the Guild Statutes book.
+25.1 The Club shall comply with the Regulation of the Guild, the Rules of the Societies Council, and all other provisions enrolled upon the Guild Statutes book.
 
-28.2 All Office Bearers and committee members shall be jointly and severally responsible for such compliance, and shall be deemed liable in the event of noncompliance therewith.
+25.2 All Office Bearers and committee members shall be jointly and severally responsible for such compliance, and shall be deemed liable in the event of noncompliance therewith.
 
-**29. EXPULSION OF MEMBERS**
+**26. EXPULSION OF MEMBERS**
 
-29.1 The Committee may by unanimous vote request any member or associate member to resign from the Club, and in the event shall cause written notification of such request to be served upon the member concerned.
+26.1 The Committee may by unanimous vote request any member or associate member to resign from the Club, and in the event shall cause written notification of such request to be served upon the member concerned.
 
-29.2 Should such a request prove ineffectual after fourteen days of written notification, the Committee may serve written notice of intended expulsion of the member concerned and should they not have resigned seven days after, the Committee may by unanimous vote expel him or her from the Club; but such expulsion shall be subject to review at the next General Meeting with the member present and to be heard.
+26.2 Should such a request prove ineffectual after fourteen days of written notification, the Committee may serve written notice of intended expulsion of the member concerned and should they not have resigned seven days after, the Committee may by unanimous vote expel him or her from the Club; but such expulsion shall be subject to review at the next General Meeting with the member present and to be heard.
 
-29.3 A person who has been expelled or has resigned their membership may not reapply for membership for the period of one year.
+26.3 A person who has been expelled or has resigned their membership may not reapply for membership for the period of one year.
 
-**30. AVAILABILITY OF CONSTITUTION**
+**27. AVAILABILITY OF CONSTITUTION**
 
-30.1 The Committee shall make this Constitution available on request to all Ordinary Members.
+27.1 The Committee shall make this Constitution available on request to all Ordinary Members.
 
-**31. INTERPRETATION**
+**28. INTERPRETATION**
 
-31.1 Subject to any provisions enrolled upon the Guild Statutes book and to any resolution passed by Guild Council, or the Societies Council, the President shall have the power to interpret the meaning of any of the provisions contained in the Constitution, but the determining decision in case of doubt shall rest with the Club in General Meeting.
+28.1 Subject to any provisions enrolled upon the Guild Statutes book and to any resolution passed by Guild Council, or the Societies Council, the President shall have the power to interpret the meaning of any of the provisions contained in the Constitution, but the determining decision in case of doubt shall rest with the Club in General Meeting.
 
-**32. AMENDMENT OF THIS CONSTITUTION**
+**29. AMENDMENT OF THIS CONSTITUTION**
 
-32.1 Any two financial Ordinary Members of the Club may not less than three days before the day appointed for the next General Meeting submit to the Secretary a notice of motion signed by them proposing an alteration to this Constitution. This shall be posted on notice boards forthwith.
+29.1 Any two financial Ordinary Members of the Club may not less than three days before the day appointed for the next General Meeting submit to the Secretary a notice of motion signed by them proposing an alteration to this Constitution. This shall be posted on notice boards forthwith.
 
-32.2 The motion may then be considered by the Club at its next meeting and amendments that are relevant to the subject matter thereof may be moved without notice.
+29.2 The motion may then be considered by the Club at its next meeting and amendments that are relevant to the subject matter thereof may be moved without notice.
 
-32.3 The motion of any amendment thereto shall not be deemed adopted unless it receives a two-thirds majority of the members present and voting.
+29.3 The motion of any amendment thereto shall not be deemed adopted unless it receives a two-thirds majority of the members present and voting.
 
-32.4 The motion as adopted with any amendments shall come into force upon receiving the approval of the Societies Council.
+29.4 The motion as adopted with any amendments shall come into force upon receiving the approval of the Societies Council.
 
-**33. DISSOLUTION OF THE CLUB**
+**30. DISSOLUTION OF THE CLUB**
 
-33.1 If upon the dissolution of the club, any property of the club remains after satisfaction of the debts and liabilities of the club that property shall be distributed to another association or club affiliated to the Societies Council which has similar objectives to those of the club, and which association shall be determined by resolution of the members.
+30.1 If upon the dissolution of the club, any property of the club remains after satisfaction of the debts and liabilities of the club that property shall be distributed to another association or club affiliated to the Societies Council which has similar objectives to those of the club, and which association shall be determined by resolution of the members.
 
 Adopted by General Meeting - 12/09/2025

--- a/Constitution.md
+++ b/Constitution.md
@@ -1,8 +1,8 @@
-**CONSTITUTION of the Coders for Causes**
+**CONSTITUTION of the Coders For Causes**
 
 **1. NAME**
 
-1.1 The formal name of the club shall be Coders for Causes.
+1.1 The formal name of the club shall be Coders For Causes.
 
 1.2 The club may also choose to go by CFC.
 

--- a/Constitution.md
+++ b/Constitution.md
@@ -38,12 +38,13 @@ To do all such things as would appear necessary and proper for the benefit or ad
 
 3.6 Any member may leave the club or resign from a particular post they hold, at any time, by providing written notice to the secretary.
 
-**4. HONORARY LIFE MEMBERS**
-4.1 The Club may in General Meeting by two-thirds majority of those present and voting confer Honorary Life Membership upon any member who has performed outstanding service to the Club. Honorary Life Members are given the rights and privileges of an Associate of the Club, unless otherwise eligible to be an Ordinary Member.
+**6. HONORARY LIFE MEMBERS**
 
-**5. PRIMACY OF ORDINARY MEMBERS**
+6.1 The Club may in General Meeting by two-thirds majority of those present and voting confer Honorary Life Membership upon any member who has performed outstanding service to the Club. Honorary Life Members are given the rights and privileges of an Associate of the Club, unless otherwise eligible to be an Ordinary Member.
 
-5.1 Only Members that are Ordinary Members shall:
+**7. PRIMACY OF ORDINARY MEMBERS**
+
+7.1 Only Members that are Ordinary Members shall:
 
 Be voting members of the Club.
 
@@ -51,29 +52,29 @@ Nominate candidates for the offices and Committee of the Club.
 
 Become or remain office bearers of the Club.
 
-**6. MEETING OF THE CLUB**
+**8. MEETING OF THE CLUB**
 
-6.1 The Club shall hold its Annual General Meeting in March of each academic year.
+8.1 The Club shall hold its Annual General Meeting in March of each academic year.
 
-6.1.1 The Club will hold its inaugural Annual General Meeting in August.
+8.1.1 The Club will hold its inaugural Annual General Meeting in August.
 
-6.2 The Committee may at any time call a Special General Meeting of the Club.
+8.2 The Committee may at any time call a Special General Meeting of the Club.
 
-6.3 The Secretary shall forthwith call a Special General Meeting upon receiving a written requisition from at least 10 financial ordinary members of the Club, and such a meeting shall be held no later than ten days immediately following receipt of such a requisition.
+8.3 The Secretary shall forthwith call a Special General Meeting upon receiving a written requisition from at least 10 financial ordinary members of the Club, and such a meeting shall be held no later than ten days immediately following receipt of such a requisition.
 
-6.4 If the Secretary fails to call the meeting within that time, any of the signatories of the requisition may do so. Any business set out in the requisition shall have priority over all the other business.
+8.4 If the Secretary fails to call the meeting within that time, any of the signatories of the requisition may do so. Any business set out in the requisition shall have priority over all the other business.
 
-**7. PROVISIONS GOVERNING GENERAL MEETINGS**
+**9. PROVISIONS GOVERNING GENERAL MEETINGS**
 
-7.1 The Secretary shall cause written notice of any General Meeting to be posted on the Guild notice boards, or in Guild mailing services, at least seven days before the date appointed for that meeting.
+9.1 The Secretary shall cause written notice of any General Meeting to be posted on the Guild notice boards, or in Guild mailing services, at least seven days before the date appointed for that meeting.
 
-7.2 No General Meeting may be held while a Guild General Meeting is in progress. This shall not apply where written notice of the meeting was given before written notice of the Guild General Meeting. Any such meeting being conducted in contravention thereof shall disband immediately on the order of disciplinary officer of the Guild.
+9.2 No General Meeting may be held while a Guild General Meeting is in progress. This shall not apply where written notice of the meeting was given before written notice of the Guild General Meeting. Any such meeting being conducted in contravention thereof shall disband immediately on the order of disciplinary officer of the Guild.
 
-7.3 The quorum of General Meeting shall consist of 10 Financial Ordinary Membership for the time being.
+9.3 The quorum of General Meeting shall consist of 10 Financial Ordinary Membership for the time being.
 
-7.4 All General Meeting of the Club shall be conducted in accordance with the procedure prescribed in the Standing Rules and Orders of the Guild Council.
+9.4 All General Meeting of the Club shall be conducted in accordance with the procedure prescribed in the Standing Rules and Orders of the Guild Council.
 
-7.5 Any General Meetings of the club involving an election must be supervised by at least one Returning Officer who shall:
+9.5 Any General Meetings of the club involving an election must be supervised by at least one Returning Officer who shall:
 
 (a) Not be contesting the election
 
@@ -81,13 +82,13 @@ Become or remain office bearers of the Club.
 
 (c) Be confirmed by the members at the General Meeting before conducting the election
 
-**8. PATRON**
+**10. PATRON**
 
-8.1 The Club may, at the Annual General Meeting, elect a patron who shall, if they indicate their willingness to do so, hold office until the succeeding Annual General Meeting; nominations shall close at that meeting.
+10.1 The Club may, at the Annual General Meeting, elect a patron who shall, if they indicate their willingness to do so, hold office until the succeeding Annual General Meeting; nominations shall close at that meeting.
 
-**9. EXECUTIVE OFFICE BEARERS**
+**12. EXECUTIVE OFFICE BEARERS**
 
-9.1 The Executive Office Bearers of the Club shall consist of, in order of seniority:
+12.1 The Executive Office Bearers of the Club shall consist of, in order of seniority:
 
 The President
 
@@ -99,9 +100,9 @@ The Secretary
 
 The Treasurer
 
-9.2 No Executive Office Bearer may hold an Executive position simultaneously within the club or with another University of WA Club. In the event it does happen, The Executive Office Bearer must step down from their Executive Position in any of Clubs.
+12.2 No Executive Office Bearer may hold an Executive position simultaneously within the club or with another University of WA Club. In the event it does happen, The Executive Office Bearer must step down from their Executive Position in any of Clubs.
 
-9.3 The Committee in meeting may dismiss an Elected Office-Bearer where, in the opinion of three quarters of the members of the Committee present and voting, that Elected Office-Bearer has:
+12.3The Committee in meeting may dismiss an Elected Office-Bearer where, in the opinion of three quarters of the members of the Committee present and voting, that Elected Office-Bearer has:
 
 (a) Consistently failed adequately to discharge the duties of that position; or
 
@@ -111,9 +112,9 @@ The Treasurer
 
 (d) Been accorded the opportunity to be present and to speak at that Committee Meeting.
 
-**10. THE COMMITTEE**
+**13. THE COMMITTEE**
 
-10.1 The Committee of the Club shall only consist of:
+13.1 The Committee of the Club shall only consist of:
 
 1. The President
 
@@ -133,13 +134,13 @@ The Treasurer
 
 9. The Immediate Past President.
 
-10.2 Only the person who held the Elected Office Bearer position of President immediately preceding the commencement of the current President‘s term shall be appointed Immediate Past President.
+13.2 Only the person who held the Elected Office Bearer position of President immediately preceding the commencement of the current President‘s term shall be appointed Immediate Past President.
 
-**11. ELECTION**
+**_. ELECTION**
 
-11.1 The Club shall hold its Annual General Meeting in March of each academic year.
+_.1 The Club shall hold its Annual General Meeting in March of each academic year.
 
-11.2 The following members of the Committee shall be elected at the Annual General Meeting:
+_.2 The following members of the Committee shall be elected at the Annual General Meeting:
 
 1. The President
 
@@ -157,73 +158,73 @@ The Treasurer
 
 8. The Fresher Representative
 
-11.3 The Secretary shall call for nominations for the above positions at least seven days before the date of the Annual General Meeting. The nominations shall close at that meeting.
+_.3 The Secretary shall call for nominations for the above positions at least seven days before the date of the Annual General Meeting. The nominations shall close at that meeting.
 
-11.4 Any Ordinary Member of the Club may vote for the positions of Committee members.
+_.4 Any Ordinary Member of the Club may vote for the positions of Committee members.
 
-11.5 Only Ordinary Members of the Club who are students at The University of Western Australia and members of the Student Guild of The University of Western Australia may hold positions on the Committee.
+_.5 Only Ordinary Members of the Club who are students at The University of Western Australia and members of the Student Guild of The University of Western Australia may hold positions on the Committee.
 
-11.6 Members may be elected to and hold at most one position on the Committee.
+_.6 Members may be elected to and hold at most one position on the Committee.
 
-11.7 The committee may choose to hold an Ordinary General Meeting in the second academic semester.
+_.7 The committee may choose to hold an Ordinary General Meeting in the second academic semester.
 
-11.7.1 At this Ordinary General Meeting, the committee may hold an election for up to two additional Ordinary Committee Members
+_.7.1 At this Ordinary General Meeting, the committee may hold an election for up to two additional Ordinary Committee Members
 
-11.7.2 The decision to hold such an election will be decided by, and announced by, the committee, at least ten days before the date of the Ordinary General Meeting.
+_.7.2 The decision to hold such an election will be decided by, and announced by, the committee, at least ten days before the date of the Ordinary General Meeting.
 
-**12. DURATION OF OFFICE**
+**14. DURATION OF OFFICE**
 
-12.1 The Executive Office Bearers and the Ordinary Committee members shall remain in office until the next Annual General Meeting.
+14.1 The Executive Office Bearers and the Ordinary Committee members shall remain in office until the next Annual General Meeting.
 
-12.2 If an Ordinary Committee Member fails to arrive to a meeting without a valid reason, they shall gain a strike. If the same member gains three strikes, they shall be removed from the position.
+14.2 If an Ordinary Committee Member fails to arrive to a meeting without a valid reason, they shall gain a strike. If the same member gains three strikes, they shall be removed from the position.
 
-12.3 If an Ordinary Committee Member fails to fulfil their role, they shall be subject to the same rules as that of an Executive Office Bearer outlined in Article 12.8 of this Constitution.
+14.3 If an Ordinary Committee Member fails to fulfil their role, they shall be subject to the same rules as that of an Executive Office Bearer outlined in Article 12.8 of this Constitution.
 
-**13. VACANCIES**
+**15. VACANCIES**
 
-13.1 If an Office Bearer resigns or ceases to hold office for any reason the remaining members of the Committee shall forthwith fill the vacancy so created by appointing thereto a member of the Committee from the Ordinary Membership, subject to review at the next General Meeting.
+15.1 If an Office Bearer resigns or ceases to hold office for any reason the remaining members of the Committee shall forthwith fill the vacancy so created by appointing thereto a member of the Committee from the Ordinary Membership, subject to review at the next General Meeting.
 
-13.2 The committee shall therefore have the power to appoint a financial member of the club as an interim Ordinary Committee Member to fill the vacancy.
+15.2 The committee shall therefore have the power to appoint a financial member of the club as an interim Ordinary Committee Member to fill the vacancy.
 
-13.3 Newly appointed Office Bearers will be ratified at the next General Meeting of the club, which shall be held no later than 2 months after the appointment/s.
+15.3 Newly appointed Office Bearers will be ratified at the next General Meeting of the club, which shall be held no later than 2 months after the appointment/s.
 
-**14. COMMITTEE MEETINGS**
+**16. COMMITTEE MEETINGS**
 
-14.1 The Committee shall meet at such times and places as the President shall determine.
+16.1 The Committee shall meet at such times and places as the President shall determine.
 
-14.2 The Secretary shall cause all members of the Committee to receive seven days’ notice before the date fixed for the meeting together with an agenda of the business to be discussed.
+16.2 The Secretary shall cause all members of the Committee to receive seven days’ notice before the date fixed for the meeting together with an agenda of the business to be discussed.
 
-14.3 The Secretary shall forthwith call a Special General Meeting of the Committee upon receiving a written requisition from at least two members thereof, and such a Special General Meeting shall be held not later than seven days immediately following receipt of requisition.
+16.3 The Secretary shall forthwith call a Special General Meeting of the Committee upon receiving a written requisition from at least two members thereof, and such a Special General Meeting shall be held not later than seven days immediately following receipt of requisition.
 
-14.4 If the Secretary fails to call the meeting within that time, any one of the members signing the requisition may do so. Any business set out in the requisition shall have priority over all other business.
+16.4 If the Secretary fails to call the meeting within that time, any one of the members signing the requisition may do so. Any business set out in the requisition shall have priority over all other business.
 
-**15. QUORUM AND PROCEDURE OF COMMITTEE**
+**17. QUORUM AND PROCEDURE OF COMMITTEE**
 
-15.1 The quorum of the Committee shall be 5 of whom at least two shall be Office Bearers.
+17.1 The quorum of the Committee shall be 5 of whom at least two shall be Office Bearers.
 
-15.2 All meetings of the Committee shall be conducted in accordance with the procedure prescribed in the Standing Rules and Orders of the Guild Council.
+17.2 All meetings of the Committee shall be conducted in accordance with the procedure prescribed in the Standing Rules and Orders of the Guild Council.
 
-**16. POWER OF COMMITTEE**
+**18. POWER OF COMMITTEE**
 
 Subject to this Constitution, the Committee shall be responsible to the Club in General Meeting for giving effect to the Objectives of the Club as set out in Article 2 and elsewhere in this Constitution and for carrying on its everyday business, and without prejudice to the generality of the foregoing, have the power to:
 
-16.1 Acquire and dispose of property; dispose of monies; open banking accounts; and enter into contracts. Unless acting under a special enabling resolution of General Meeting, however, the Committee shall not borrow or raise money or incur debts or liabilities on behalf of or in the name of the Club to a greater amount than five dollars for each and every then existing financial Ordinary Member of the Club.
+18.1 Acquire and dispose of property; dispose of monies; open banking accounts; and enter into contracts. Unless acting under a special enabling resolution of General Meeting, however, the Committee shall not borrow or raise money or incur debts or liabilities on behalf of or in the name of the Club to a greater amount than five dollars for each and every then existing financial Ordinary Member of the Club.
 
-16.2 Make regulations for the orderly and proper management of the affairs of the Club, ensuring that no regulation is inconsistent or repugnant with this Constitution.
+18.2 Make regulations for the orderly and proper management of the affairs of the Club, ensuring that no regulation is inconsistent or repugnant with this Constitution.
 
-16.3 Make, alter or repeal By-Laws and impose fines for the breach therefore. All By-Laws and any alterations or amendment therefore shall be subject to ratification by Societies Council and Guild Council before coming into force. The maximum fine imposed may not exceed five dollars.
+18.3 Make, alter or repeal By-Laws and impose fines for the breach therefore. All By-Laws and any alterations or amendment therefore shall be subject to ratification by Societies Council and Guild Council before coming into force. The maximum fine imposed may not exceed five dollars.
 
-**17. CHAIR**
+**19. CHAIR**
 
-17.1 The President shall have the right to take the Chair at any meeting of the Club or of the Committee.
+19.1 The President shall have the right to take the Chair at any meeting of the Club or of the Committee.
 
-17.2 If the President is absent or does not wish to exercise his right at any meeting, that right shall develop upon the Vice President.
+19.2 If the President is absent or does not wish to exercise his right at any meeting, that right shall develop upon the Vice President.
 
-17.3 In the event of absence of both the President and the Vice President, or in event of them both not wishing to exercise their right, that meeting shall elect its own Chair.
+19.3 In the event of absence of both the President and the Vice President, or in event of them both not wishing to exercise their right, that meeting shall elect its own Chair.
 
-**18. PRESIDENT**
+**20. PRESIDENT**
 
-18.1 In addition to any provisions set out elsewhere in this Constitution or in any By-Laws or Regulations made hereunder, it shall be the duty of the President to:
+20.1 In addition to any provisions set out elsewhere in this Constitution or in any By-Laws or Regulations made hereunder, it shall be the duty of the President to:
 
 (a) Coordinate and supervise the work of the Executive Office Bearers, subject to the authority of the Club in General Meeting.
 
@@ -233,17 +234,17 @@ Subject to this Constitution, the Committee shall be responsible to the Club in 
 
 (d) Report on the status of the club to the ordinary members at all general meetings.
 
-**19. VICE PRESIDENT**
+**21. VICE PRESIDENT**
 
-19.1 In addition to any provisions set out elsewhere in the Constitution or in any By-Laws or Regulations made hereunder, it shall be the duty of the Vice President to:
+21.1 In addition to any provisions set out elsewhere in the Constitution or in any By-Laws or Regulations made hereunder, it shall be the duty of the Vice President to:
 
 (a) Seek, engage and maintain client relationships, as well as source projects, and oversee their delivery.
 
 (b) assist the President wherever possible.
 
-**20. TECHNICAL LEAD**
+**22. TECHNICAL LEAD**
 
-20.1 In addition to any provisions set out elsewhere in the Constitution or in any By-Laws or Regulations made hereunder, it shall be the duty of the Technical Lead:
+22.1 In addition to any provisions set out elsewhere in the Constitution or in any By-Laws or Regulations made hereunder, it shall be the duty of the Technical Lead:
 
 (a) To advise the Committee on technical and development related matters.
 
@@ -251,9 +252,9 @@ Subject to this Constitution, the Committee shall be responsible to the Club in 
 
 (c) To conduct code reviews and assist with project development if requested.
 
-**21. SECRETARY**
+**23. SECRETARY**
 
-21.1 In addition to any provisions set out elsewhere in the Constitution or in any By-Laws or Regulations made hereunder, it shall be the duty of the Secretary:
+23.1 In addition to any provisions set out elsewhere in the Constitution or in any By-Laws or Regulations made hereunder, it shall be the duty of the Secretary:
 
 (a) To record all proceedings of the Club and the Committee in a Club Minute Book which they shall cause to be provided for that purpose:
 
@@ -271,9 +272,9 @@ To lodge with the Secretary of the Societies Council a copy of the Constitution 
 
 (e) In the event of the Club being de-registered, to present to the Societies Council Secretary within thirty days a duly audited statement of the financial position of the Club together with a copy of the resolution, which may have been passed by the Club as to the disposition of its funds.
 
-**22. TREASURER**
+**24. TREASURER**
 
-22.1 In addition to any provisions set out elsewhere in the Constitution or in any By-Laws or Regulations made hereunder, it shall be the duty of the Treasurer:
+24.1 In addition to any provisions set out elsewhere in the Constitution or in any By-Laws or Regulations made hereunder, it shall be the duty of the Treasurer:
 
 Keep proper books of account dealing with the property and finances of the Club and to furnish the Committee with such accounts and information relating to the finances and property of the Club as the Committee from time to time require.
 
@@ -285,52 +286,52 @@ Produce and deliver all necessary books, vouchers and other documents to the per
 
 Prepare necessary forms, and receipts for Societies Council in accordance with Societies Council grant policies.
 
-**23. DEPOSITS AND WITHDRAWAL OF MONIES**
+**25. DEPOSITS AND WITHDRAWAL OF MONIES**
 
-23.1 All monies due and payable to the Club shall be received by the Treasurer who shall lodge them without undue delay with Guild Finance for the credit of the Club.
+25.1 All monies due and payable to the Club shall be received by the Treasurer who shall lodge them without undue delay with Guild Finance for the credit of the Club.
 
-23.2 Any two members of the Executive may jointly sign cheques and forms of authority for the payment of funds of the Society.
+25.2 Any two members of the Executive may jointly sign cheques and forms of authority for the payment of funds of the Society.
 
-23.3 Notwithstanding anything contained herein, no persons shall deposit or withdraw any monies into any account that Guild Council has closed by resolution.
+25.3 Notwithstanding anything contained herein, no persons shall deposit or withdraw any monies into any account that Guild Council has closed by resolution.
 
-**24. PAYMENTS**
+**26. PAYMENTS**
 
-24.1 No payments shall be made on behalf or in the name of the Club unless it has been authorised by the Executive Office Bearers, in accordance with Article 2.2
+26.1 No payments shall be made on behalf or in the name of the Club unless it has been authorised by the Executive Office Bearers, in accordance with Article 2.2
 
-**25. MAJOR OBLIGATIONS TO GUILD**
+**27. MAJOR OBLIGATIONS TO GUILD**
 
-25.1 The Club shall comply with the Regulation of the Guild, the Rules of the Societies Council, and all other provisions enrolled upon the Guild Statutes book.
+27.1 The Club shall comply with the Regulation of the Guild, the Rules of the Societies Council, and all other provisions enrolled upon the Guild Statutes book.
 
-25.2 All Office Bearers and committee members shall be jointly and severally responsible for such compliance, and shall be deemed liable in the event of noncompliance therewith.
+27.2 All Office Bearers and committee members shall be jointly and severally responsible for such compliance, and shall be deemed liable in the event of noncompliance therewith.
 
-**26. EXPULSION OF MEMBERS**
+**28. EXPULSION OF MEMBERS**
 
-26.1 The Committee may by unanimous vote request any member or associate member to resign from the Club, and in the event shall cause written notification of such request to be served upon the member concerned.
+28.1 The Committee may by unanimous vote request any member or associate member to resign from the Club, and in the event shall cause written notification of such request to be served upon the member concerned.
 
-26.2 Should such a request prove ineffectual after fourteen days of written notification, the Committee may serve written notice of intended expulsion of the member concerned and should they not have resigned seven days after, the Committee may by unanimous vote expel him or her from the Club; but such expulsion shall be subject to review at the next General Meeting with the member present and to be heard.
+28.2 Should such a request prove ineffectual after fourteen days of written notification, the Committee may serve written notice of intended expulsion of the member concerned and should they not have resigned seven days after, the Committee may by unanimous vote expel him or her from the Club; but such expulsion shall be subject to review at the next General Meeting with the member present and to be heard.
 
-26.3 A person who has been expelled or has resigned their membership may not reapply for membership for the period of one year.
+28.3 A person who has been expelled or has resigned their membership may not reapply for membership for the period of one year.
 
-**27. AVAILABILITY OF CONSTITUTION**
+**29. AVAILABILITY OF CONSTITUTION**
 
-27.1 The Committee shall make this Constitution available on request to all Ordinary Members.
+29.1 The Committee shall make this Constitution available on request to all Ordinary Members.
 
-**28. INTERPRETATION**
+**30. INTERPRETATION**
 
-28.1 Subject to any provisions enrolled upon the Guild Statutes book and to any resolution passed by Guild Council, or the Societies Council, the President shall have the power to interpret the meaning of any of the provisions contained in the Constitution, but the determining decision in case of doubt shall rest with the Club in General Meeting.
+30.1 Subject to any provisions enrolled upon the Guild Statutes book and to any resolution passed by Guild Council, or the Societies Council, the President shall have the power to interpret the meaning of any of the provisions contained in the Constitution, but the determining decision in case of doubt shall rest with the Club in General Meeting.
 
-**29. AMENDMENT OF THIS CONSTITUTION**
+**31. AMENDMENT OF THIS CONSTITUTION**
 
-29.1 Any two financial Ordinary Members of the Club may not less than three days before the day appointed for the next General Meeting submit to the Secretary a notice of motion signed by them proposing an alteration to this Constitution. This shall be posted on notice boards forthwith.
+31.1 Any two financial Ordinary Members of the Club may not less than three days before the day appointed for the next General Meeting submit to the Secretary a notice of motion signed by them proposing an alteration to this Constitution. This shall be posted on notice boards forthwith.
 
-29.2 The motion may then be considered by the Club at its next meeting and amendments that are relevant to the subject matter thereof may be moved without notice.
+31.2 The motion may then be considered by the Club at its next meeting and amendments that are relevant to the subject matter thereof may be moved without notice.
 
-29.3 The motion of any amendment thereto shall not be deemed adopted unless it receives a two-thirds majority of the members present and voting.
+31.3 The motion of any amendment thereto shall not be deemed adopted unless it receives a two-thirds majority of the members present and voting.
 
-29.4 The motion as adopted with any amendments shall come into force upon receiving the approval of the Societies Council.
+31.4 The motion as adopted with any amendments shall come into force upon receiving the approval of the Societies Council.
 
-**30. DISSOLUTION OF THE CLUB**
+**32. DISSOLUTION OF THE CLUB**
 
-30.1 If upon the dissolution of the club, any property of the club remains after satisfaction of the debts and liabilities of the club that property shall be distributed to another association or club affiliated to the Societies Council which has similar objectives to those of the club, and which association shall be determined by resolution of the members.
+32.1 If upon the dissolution of the club, any property of the club remains after satisfaction of the debts and liabilities of the club that property shall be distributed to another association or club affiliated to the Societies Council which has similar objectives to those of the club, and which association shall be determined by resolution of the members.
 
 Adopted by General Meeting - 12/09/2025

--- a/Constitution.md
+++ b/Constitution.md
@@ -20,7 +20,7 @@ To do all such things as would appear necessary and proper for the benefit or ad
 
 2.2 The property and income of the society shall be applied solely towards the promotion of the objectives of the club and no part of that property or income may be paid or otherwise distributed, directly or indirectly, to members, except in good faith and in the promotion of those objectives.
 
-**3. ORDINARY MEMBERSHIP**
+**3. MEMBERSHIP**
 
 3.1 Memberships are open to any person who shares the aims of the Club and agrees to comply with the constitution and rules of the Club.
 
@@ -34,17 +34,17 @@ To do all such things as would appear necessary and proper for the benefit or ad
 
 3.4 Persons may be an Ordinary Member or an associate member but not both.
 
-3.5 A subscription shall expire at the commencement of the Annual General Meeting in the calendar year subsequent to its payment.
+3.5 A subscription shall expire a year from the date of its purchase.
 
 3.6 Any member may leave the club or resign from a particular post they hold, at any time, by providing written notice to the secretary.
 
-**6. HONORARY LIFE MEMBERS**
+**4. HONORARY LIFE MEMBERS**
 
-6.1 The Club may in General Meeting by two-thirds majority of those present and voting confer Honorary Life Membership upon any member who has performed outstanding service to the Club. Honorary Life Members are given the rights and privileges of an Associate of the Club, unless otherwise eligible to be an Ordinary Member.
+4.1 The Club may in General Meeting by two-thirds majority of those present and voting confer Honorary Life Membership upon any member who has performed outstanding service to the Club. Honorary Life Members are given the rights and privileges of an Associate of the Club, unless otherwise eligible to be an Ordinary Member.
 
-**7. PRIMACY OF ORDINARY MEMBERS**
+**4. PRIMACY OF ORDINARY MEMBERS**
 
-7.1 Only Members that are Ordinary Members shall:
+4.1 Only Members that are Ordinary Members shall:
 
 Be voting members of the Club.
 
@@ -52,29 +52,29 @@ Nominate candidates for the offices and Committee of the Club.
 
 Become or remain office bearers of the Club.
 
-**8. MEETING OF THE CLUB**
+**5. MEETING OF THE CLUB**
 
-8.1 The Club shall hold its Annual General Meeting in March of each academic year.
+5.1 The Club shall hold its Annual General Meeting in March of each academic year.
 
-8.1.1 The Club will hold its inaugural Annual General Meeting in August.
+5.1.1 The Club will hold its inaugural Annual General Meeting in August.
 
-8.2 The Committee may at any time call a Special General Meeting of the Club.
+5.2 The Committee may at any time call a Special General Meeting of the Club.
 
-8.3 The Secretary shall forthwith call a Special General Meeting upon receiving a written requisition from at least 10 financial ordinary members of the Club, and such a meeting shall be held no later than ten days immediately following receipt of such a requisition.
+5.3 The Secretary shall forthwith call a Special General Meeting upon receiving a written requisition from at least 10 financial ordinary members of the Club, and such a meeting shall be held no later than ten days immediately following receipt of such a requisition.
 
-8.4 If the Secretary fails to call the meeting within that time, any of the signatories of the requisition may do so. Any business set out in the requisition shall have priority over all the other business.
+5.4 If the Secretary fails to call the meeting within that time, any of the signatories of the requisition may do so. Any business set out in the requisition shall have priority over all the other business.
 
-**9. PROVISIONS GOVERNING GENERAL MEETINGS**
+**6. PROVISIONS GOVERNING GENERAL MEETINGS**
 
-9.1 The Secretary shall cause written notice of any General Meeting to be posted on the Guild notice boards, or in Guild mailing services, at least seven days before the date appointed for that meeting.
+6.1 The Secretary shall cause written notice of any General Meeting to be posted on the Guild notice boards, or in Guild mailing services, at least seven days before the date appointed for that meeting.
 
-9.2 No General Meeting may be held while a Guild General Meeting is in progress. This shall not apply where written notice of the meeting was given before written notice of the Guild General Meeting. Any such meeting being conducted in contravention thereof shall disband immediately on the order of disciplinary officer of the Guild.
+6.2 No General Meeting may be held while a Guild General Meeting is in progress. This shall not apply where written notice of the meeting was given before written notice of the Guild General Meeting. Any such meeting being conducted in contravention thereof shall disband immediately on the order of disciplinary officer of the Guild.
 
-9.3 The quorum of General Meeting shall consist of 10 Financial Ordinary Membership for the time being.
+6.3 The quorum of General Meeting shall consist of 10 Financial Ordinary Membership for the time being.
 
-9.4 All General Meeting of the Club shall be conducted in accordance with the procedure prescribed in the Standing Rules and Orders of the Guild Council.
+6.4 All General Meeting of the Club shall be conducted in accordance with the procedure prescribed in the Standing Rules and Orders of the Guild Council.
 
-9.5 Any General Meetings of the club involving an election must be supervised by at least one Returning Officer who shall:
+6.5 Any General Meetings of the club involving an election must be supervised by at least one Returning Officer who shall:
 
 (a) Not be contesting the election
 
@@ -82,13 +82,13 @@ Become or remain office bearers of the Club.
 
 (c) Be confirmed by the members at the General Meeting before conducting the election
 
-**10. PATRON**
+**7. PATRON**
 
-10.1 The Club may, at the Annual General Meeting, elect a patron who shall, if they indicate their willingness to do so, hold office until the succeeding Annual General Meeting; nominations shall close at that meeting.
+7.1 The Club may, at the Annual General Meeting, elect a patron who shall, if they indicate their willingness to do so, hold office until the succeeding Annual General Meeting; nominations shall close at that meeting.
 
-**12. EXECUTIVE OFFICE BEARERS**
+**7. EXECUTIVE OFFICE BEARERS**
 
-12.1 The Executive Office Bearers of the Club shall consist of, in order of seniority:
+7.1 The Executive Office Bearers of the Club shall consist of, in order of seniority:
 
 The President
 
@@ -100,9 +100,9 @@ The Secretary
 
 The Treasurer
 
-12.2 No Executive Office Bearer may hold an Executive position simultaneously within the club or with another University of WA Club. In the event it does happen, The Executive Office Bearer must step down from their Executive Position in any of Clubs.
+7.2 No Executive Office Bearer may hold an Executive position simultaneously within the club or with another University of WA Club. In the event it does happen, The Executive Office Bearer must step down from their Executive Position in any of Clubs.
 
-12.3 The Committee in meeting may dismiss an Elected Office-Bearer where, in the opinion of three quarters of the members of the Committee present and voting, that Elected Office-Bearer has:
+7.3 The Committee in meeting may dismiss an Elected Office-Bearer where, in the opinion of three quarters of the members of the Committee present and voting, that Elected Office-Bearer has:
 
 (a) Consistently failed adequately to discharge the duties of that position; or
 
@@ -112,9 +112,9 @@ The Treasurer
 
 (d) Been accorded the opportunity to be present and to speak at that Committee Meeting.
 
-**13. THE COMMITTEE**
+**8. THE COMMITTEE**
 
-13.1 The Committee of the Club shall only consist of:
+8.1 The Committee of the Club shall only consist of:
 
 1. The President
 
@@ -134,13 +134,13 @@ The Treasurer
 
 9. The Immediate Past President.
 
-13.2 Only the person who held the Elected Office Bearer position of President immediately preceding the commencement of the current President‘s term shall be appointed Immediate Past President.
+8.2 Only the person who held the Elected Office Bearer position of President immediately preceding the commencement of the current President‘s term shall be appointed Immediate Past President.
 
-**_. ELECTION**
+**9. ELECTION**
 
-_.1 The Club shall hold its Annual General Meeting in March of each academic year.
+9.1 The Club shall hold its Annual General Meeting in March of each academic year.
 
-_.2 The following members of the Committee shall be elected at the Annual General Meeting:
+9.2 The following members of the Committee shall be elected at the Annual General Meeting:
 
 1. The President
 
@@ -158,73 +158,72 @@ _.2 The following members of the Committee shall be elected at the Annual Genera
 
 8. The Fresher Representative
 
-_.3 The Secretary shall call for nominations for the above positions at least seven days before the date of the Annual General Meeting. The nominations shall close at that meeting.
+9.3 The Secretary shall call for nominations for the above positions at least seven days before the date of the Annual General Meeting. The nominations shall close at that meeting.
 
-_.4 Any Ordinary Member of the Club may vote for the positions of Committee members.
+9.4 Any Ordinary Member of the Club may vote for the positions of Committee members.
 
-_.5 Only Ordinary Members of the Club who are students at The University of Western Australia and members of the Student Guild of The University of Western Australia may hold positions on the Committee.
+9.5 Only Ordinary Members of the Club who are students at The University of Western Australia and members of the Student Guild of The University of Western Australia may hold positions on the Committee.
 
-_.6 Members may be elected to and hold at most one position on the Committee.
+9.6 Members may be elected to and hold at most one position on the Committee.
 
-_.7 The committee may choose to hold an Ordinary General Meeting in the second academic semester.
+9.7 The committee may choose to hold an Ordinary General Meeting at least one month after the Annual General Meeting, at which an election may be held for:
+    - Up to two additional Ordinary Committee Members
 
-_.7.1 At this Ordinary General Meeting, the committee may hold an election for up to two additional Ordinary Committee Members
+9.7.1 The decision to hold such an election will be decided by, and announced by, the committee, at least ten days before the date of the Ordinary General Meeting.
 
-_.7.2 The decision to hold such an election will be decided by, and announced by, the committee, at least ten days before the date of the Ordinary General Meeting.
+**10. DURATION OF OFFICE**
 
-**14. DURATION OF OFFICE**
+10.1 The Executive Office Bearers and the Ordinary Committee members shall remain in office until the next Annual General Meeting.
 
-14.1 The Executive Office Bearers and the Ordinary Committee members shall remain in office until the next Annual General Meeting.
+10.2 If an Ordinary Committee Member fails to arrive to a meeting without a valid reason, they shall gain a strike. If the same member gains three strikes, they shall be removed from the position.
 
-14.2 If an Ordinary Committee Member fails to arrive to a meeting without a valid reason, they shall gain a strike. If the same member gains three strikes, they shall be removed from the position.
+10.3 If an Ordinary Committee Member fails to fulfil their role, they shall be subject to the same rules as that of an Executive Office Bearer outlined in Article 7.3 of this Constitution.
 
-14.3 If an Ordinary Committee Member fails to fulfil their role, they shall be subject to the same rules as that of an Executive Office Bearer outlined in Article 12.3 of this Constitution.
+**11. VACANCIES**
 
-**15. VACANCIES**
+11.1 If an Office Bearer resigns or ceases to hold office for any reason the remaining members of the Committee shall forthwith fill the vacancy so created by appointing thereto a member of the Committee from the Ordinary Membership, subject to review at the next General Meeting.
 
-15.1 If an Office Bearer resigns or ceases to hold office for any reason the remaining members of the Committee shall forthwith fill the vacancy so created by appointing thereto a member of the Committee from the Ordinary Membership, subject to review at the next General Meeting.
+11.2 The committee shall therefore have the power to appoint a financial member of the club as an interim Ordinary Committee Member to fill the vacancy.
 
-15.2 The committee shall therefore have the power to appoint a financial member of the club as an interim Ordinary Committee Member to fill the vacancy.
+11.3 Newly appointed Office Bearers will be ratified at the next General Meeting of the club, which shall be held no later than 2 months after the appointment/s.
 
-15.3 Newly appointed Office Bearers will be ratified at the next General Meeting of the club, which shall be held no later than 2 months after the appointment/s.
+**11. COMMITTEE MEETINGS**
 
-**16. COMMITTEE MEETINGS**
+11.1 The Committee shall meet at such times and places as the President shall determine.
 
-16.1 The Committee shall meet at such times and places as the President shall determine.
+11.2 The Secretary shall cause all members of the Committee to receive seven days’ notice before the date fixed for the meeting together with an agenda of the business to be discussed.
 
-16.2 The Secretary shall cause all members of the Committee to receive seven days’ notice before the date fixed for the meeting together with an agenda of the business to be discussed.
+11.3 The Secretary shall forthwith call a Special General Meeting of the Committee upon receiving a written requisition from at least two members thereof, and such a Special General Meeting shall be held not later than seven days immediately following receipt of requisition.
 
-16.3 The Secretary shall forthwith call a Special General Meeting of the Committee upon receiving a written requisition from at least two members thereof, and such a Special General Meeting shall be held not later than seven days immediately following receipt of requisition.
+11.4 If the Secretary fails to call the meeting within that time, any one of the members signing the requisition may do so. Any business set out in the requisition shall have priority over all other business.
 
-16.4 If the Secretary fails to call the meeting within that time, any one of the members signing the requisition may do so. Any business set out in the requisition shall have priority over all other business.
+**12. QUORUM AND PROCEDURE OF COMMITTEE**
 
-**17. QUORUM AND PROCEDURE OF COMMITTEE**
+12.1 The quorum of the Committee shall be 5 of whom at least two shall be Office Bearers.
 
-17.1 The quorum of the Committee shall be 5 of whom at least two shall be Office Bearers.
+12.2 All meetings of the Committee shall be conducted in accordance with the procedure prescribed in the Standing Rules and Orders of the Guild Council.
 
-17.2 All meetings of the Committee shall be conducted in accordance with the procedure prescribed in the Standing Rules and Orders of the Guild Council.
-
-**18. POWER OF COMMITTEE**
+**13. POWER OF COMMITTEE**
 
 Subject to this Constitution, the Committee shall be responsible to the Club in General Meeting for giving effect to the Objectives of the Club as set out in Article 2 and elsewhere in this Constitution and for carrying on its everyday business, and without prejudice to the generality of the foregoing, have the power to:
 
-18.1 Acquire and dispose of property; dispose of monies; open banking accounts; and enter into contracts. Unless acting under a special enabling resolution of General Meeting, however, the Committee shall not borrow or raise money or incur debts or liabilities on behalf of or in the name of the Club to a greater amount than five dollars for each and every then existing financial Ordinary Member of the Club.
+13.1 Acquire and dispose of property; dispose of monies; open banking accounts; and enter into contracts. Unless acting under a special enabling resolution of General Meeting, however, the Committee shall not borrow or raise money or incur debts or liabilities on behalf of or in the name of the Club to a greater amount than five dollars for each and every then existing financial Ordinary Member of the Club.
 
-18.2 Make regulations for the orderly and proper management of the affairs of the Club, ensuring that no regulation is inconsistent or repugnant with this Constitution.
+13.2 Make regulations for the orderly and proper management of the affairs of the Club, ensuring that no regulation is inconsistent or repugnant with this Constitution.
 
-18.3 Make, alter or repeal By-Laws and impose fines for the breach therefore. All By-Laws and any alterations or amendment therefore shall be subject to ratification by Societies Council and Guild Council before coming into force. The maximum fine imposed may not exceed five dollars.
+13.3 Make, alter or repeal By-Laws and impose fines for the breach therefore. All By-Laws and any alterations or amendment therefore shall be subject to ratification by Societies Council and Guild Council before coming into force. The maximum fine imposed may not exceed five dollars.
 
-**19. CHAIR**
+**14. CHAIR**
 
-19.1 The President shall have the right to take the Chair at any meeting of the Club or of the Committee.
+14.1 The President shall have the right to take the Chair at any meeting of the Club or of the Committee.
 
-19.2 If the President is absent or does not wish to exercise his right at any meeting, that right shall develop upon the Vice President.
+14.2 If the President is absent or does not wish to exercise his right at any meeting, that right shall develop upon the Vice President.
 
-19.3 In the event of absence of both the President and the Vice President, or in event of them both not wishing to exercise their right, that meeting shall elect its own Chair.
+14.3 In the event of absence of both the President and the Vice President, or in event of them both not wishing to exercise their right, that meeting shall elect its own Chair.
 
-**20. PRESIDENT**
+**15. PRESIDENT**
 
-20.1 In addition to any provisions set out elsewhere in this Constitution or in any By-Laws or Regulations made hereunder, it shall be the duty of the President to:
+15.1 In addition to any provisions set out elsewhere in this Constitution or in any By-Laws or Regulations made hereunder, it shall be the duty of the President to:
 
 (a) Coordinate and supervise the work of the Executive Office Bearers, subject to the authority of the Club in General Meeting.
 
@@ -234,17 +233,17 @@ Subject to this Constitution, the Committee shall be responsible to the Club in 
 
 (d) Report on the status of the club to the ordinary members at all general meetings.
 
-**21. VICE PRESIDENT**
+**16. VICE PRESIDENT**
 
-21.1 In addition to any provisions set out elsewhere in the Constitution or in any By-Laws or Regulations made hereunder, it shall be the duty of the Vice President to:
+16.1 In addition to any provisions set out elsewhere in the Constitution or in any By-Laws or Regulations made hereunder, it shall be the duty of the Vice President to:
 
 (a) Seek, engage and maintain client relationships, as well as source projects, and oversee their delivery.
 
 (b) assist the President wherever possible.
 
-**22. TECHNICAL LEAD**
+**17. TECHNICAL LEAD**
 
-22.1 In addition to any provisions set out elsewhere in the Constitution or in any By-Laws or Regulations made hereunder, it shall be the duty of the Technical Lead:
+17.1 In addition to any provisions set out elsewhere in the Constitution or in any By-Laws or Regulations made hereunder, it shall be the duty of the Technical Lead:
 
 (a) To advise the Committee on technical and development related matters.
 
@@ -252,9 +251,9 @@ Subject to this Constitution, the Committee shall be responsible to the Club in 
 
 (c) To conduct code reviews and assist with project development if requested.
 
-**23. SECRETARY**
+**18. SECRETARY**
 
-23.1 In addition to any provisions set out elsewhere in the Constitution or in any By-Laws or Regulations made hereunder, it shall be the duty of the Secretary:
+18.1 In addition to any provisions set out elsewhere in the Constitution or in any By-Laws or Regulations made hereunder, it shall be the duty of the Secretary:
 
 (a) To record the proceedings of all General Meetings and meetings of the Committee and make these minutes available in an easily accessible portion of the Club's online presence.
 
@@ -272,9 +271,9 @@ To lodge with the Secretary of the Societies Council a copy of the Constitution 
 
 (e) In the event of the Club being de-registered, to present to the Societies Council Secretary within thirty days a duly audited statement of the financial position of the Club together with a copy of the resolution, which may have been passed by the Club as to the disposition of its funds.
 
-**24. TREASURER**
+**19. TREASURER**
 
-24.1 In addition to any provisions set out elsewhere in the Constitution or in any By-Laws or Regulations made hereunder, it shall be the duty of the Treasurer:
+19.1 In addition to any provisions set out elsewhere in the Constitution or in any By-Laws or Regulations made hereunder, it shall be the duty of the Treasurer:
 
 Keep proper books of account dealing with the property and finances of the Club and to furnish the Committee with such accounts and information relating to the finances and property of the Club as the Committee from time to time require.
 
@@ -286,52 +285,52 @@ Produce and deliver all necessary books, vouchers and other documents to the per
 
 Prepare necessary forms, and receipts for Societies Council in accordance with Societies Council grant policies.
 
-**25. DEPOSITS AND WITHDRAWAL OF MONIES**
+**20. DEPOSITS AND WITHDRAWAL OF MONIES**
 
-25.1 All monies due and payable to the Club shall be received by the Treasurer who shall lodge them without undue delay with Guild Finance for the credit of the Club.
+20.1 All monies due and payable to the Club shall be received by the Treasurer who shall lodge them without undue delay with Guild Finance for the credit of the Club.
 
-25.2 Any two members of the Executive may jointly sign cheques and forms of authority for the payment of funds of the Society.
+20.2 Any two members of the Executive may jointly sign cheques and forms of authority for the payment of funds of the Society.
 
-25.3 Notwithstanding anything contained herein, no persons shall deposit or withdraw any monies into any account that Guild Council has closed by resolution.
+20.3 Notwithstanding anything contained herein, no persons shall deposit or withdraw any monies into any account that Guild Council has closed by resolution.
 
-**26. PAYMENTS**
+**21. PAYMENTS**
 
-26.1 No payments shall be made on behalf or in the name of the Club unless it has been authorised by the Executive Office Bearers, in accordance with Article 2.2
+21.1 No payments shall be made on behalf or in the name of the Club unless it has been authorised by the Executive Office Bearers, in accordance with Article 2.2
 
-**27. MAJOR OBLIGATIONS TO GUILD**
+**22. MAJOR OBLIGATIONS TO GUILD**
 
-27.1 The Club shall comply with the Regulation of the Guild, the Rules of the Societies Council, and all other provisions enrolled upon the Guild Statutes book.
+22.1 The Club shall comply with the Regulation of the Guild, the Rules of the Societies Council, and all other provisions enrolled upon the Guild Statutes book.
 
-27.2 All Office Bearers and committee members shall be jointly and severally responsible for such compliance, and shall be deemed liable in the event of noncompliance therewith.
+22.2 All Office Bearers and committee members shall be jointly and severally responsible for such compliance, and shall be deemed liable in the event of noncompliance therewith.
 
-**28. EXPULSION OF MEMBERS**
+**23. EXPULSION OF MEMBERS**
 
-28.1 The Committee may by unanimous vote request any member or associate member to resign from the Club, and in the event shall cause written notification of such request to be served upon the member concerned.
+23.1 The Committee may by unanimous vote request any member or associate member to resign from the Club, and in the event shall cause written notification of such request to be served upon the member concerned.
 
-28.2 Should such a request prove ineffectual after fourteen days of written notification, the Committee may serve written notice of intended expulsion of the member concerned and should they not have resigned seven days after, the Committee may by unanimous vote expel him or her from the Club; but such expulsion shall be subject to review at the next General Meeting with the member present and to be heard.
+23.2 Should such a request prove ineffectual after fourteen days of written notification, the Committee may serve written notice of intended expulsion of the member concerned and should they not have resigned seven days after, the Committee may by unanimous vote expel him or her from the Club; but such expulsion shall be subject to review at the next General Meeting with the member present and to be heard.
 
-28.3 A person who has been expelled or has resigned their membership may not reapply for membership for the period of one year.
+23.3 A person who has been expelled or has resigned their membership may not reapply for membership for the period of one year.
 
-**29. AVAILABILITY OF CONSTITUTION**
+**24. AVAILABILITY OF CONSTITUTION**
 
-29.1 The Committee shall make this Constitution available on request to all Ordinary Members.
+24.1 The Committee shall make this Constitution available on request to all Ordinary Members.
 
-**30. INTERPRETATION**
+**25. INTERPRETATION**
 
-30.1 Subject to any provisions enrolled upon the Guild Statutes book and to any resolution passed by Guild Council, or the Societies Council, the President shall have the power to interpret the meaning of any of the provisions contained in the Constitution, but the determining decision in case of doubt shall rest with the Club in General Meeting.
+25.1 Subject to any provisions enrolled upon the Guild Statutes book and to any resolution passed by Guild Council, or the Societies Council, the President shall have the power to interpret the meaning of any of the provisions contained in the Constitution, but the determining decision in case of doubt shall rest with the Club in General Meeting.
 
-**31. AMENDMENT OF THIS CONSTITUTION**
+**26. AMENDMENT OF THIS CONSTITUTION**
 
-31.1 Any two financial Ordinary Members of the Club may not less than three days before the day appointed for the next General Meeting submit to the Secretary a notice of motion signed by them proposing an alteration to this Constitution. This shall be posted on notice boards forthwith.
+26.1 Any two financial Ordinary Members of the Club may not less than three days before the day appointed for the next General Meeting submit to the Secretary a notice of motion signed by them proposing an alteration to this Constitution. This shall be posted on notice boards forthwith.
 
-31.2 The motion may then be considered by the Club at its next meeting and amendments that are relevant to the subject matter thereof may be moved without notice.
+26.2 The motion may then be considered by the Club at its next meeting and amendments that are relevant to the subject matter thereof may be moved without notice.
 
-31.3 The motion of any amendment thereto shall not be deemed adopted unless it receives a two-thirds majority of the members present and voting.
+26.3 The motion of any amendment thereto shall not be deemed adopted unless it receives a two-thirds majority of the members present and voting.
 
-31.4 The motion as adopted with any amendments shall come into force upon receiving the approval of the Societies Council.
+26.4 The motion as adopted with any amendments shall come into force upon receiving the approval of the Societies Council.
 
-**32. DISSOLUTION OF THE CLUB**
+**27. DISSOLUTION OF THE CLUB**
 
-32.1 If upon the dissolution of the club, any property of the club remains after satisfaction of the debts and liabilities of the club that property shall be distributed to another association or club affiliated to the Societies Council which has similar objectives to those of the club, and which association shall be determined by resolution of the members.
+27.1 If upon the dissolution of the club, any property of the club remains after satisfaction of the debts and liabilities of the club that property shall be distributed to another association or club affiliated to the Societies Council which has similar objectives to those of the club, and which association shall be determined by resolution of the members.
 
 Adopted by General Meeting - 12/09/2025

--- a/Constitution.md
+++ b/Constitution.md
@@ -22,51 +22,29 @@ To do all such things as would appear necessary and proper for the benefit or ad
 
 **3. ORDINARY MEMBERSHIP**
 
-3.1 Ordinary membership shall be confined to:
+3.1 Memberships are open to any person who shares the aims of the Club and agrees to comply with the constitution and rules of the Club.
 
-Members of the Guild
+3.2 A subscription for an Ordinary Membership may be made payable to the Club if the Committee so desires.
 
-Associates of the Guild
+3.2.1 A subscription for an Ordinary Membership may only be bought by an enrolled Student of the University of Western Australia and a current member of the University of Western Australia Student Guild.
 
-Honorary Life Associates of the Guild
+3.3 A subscription for an Associate Membership may be made payable to the Club if the Committee so desires.
 
-Members of the University Senate
+3.3.1 A subscription for an Associate Membership may be bought by a member of the public.
 
-Members of the University Staff
+3.4 Persons may be an Ordinary Member or an associate member but not both.
 
-Students enrolled at the University of Western Australia.
+3.5 A subscription shall expire at the commencement of the Annual General Meeting in the calendar year subsequent to its payment.
 
-3.2 Any potential member that meets the requirements in 3.1 has the right to join the club.
-
-**4. ASSOCIATESHIP OF THE CLUB**
-
-4.1 The Club in General Meeting may from time to time admit persons to associateship that are, or have been:
-
-Members of the Guild
-
-Associates of the Guild
-
-Honorary Life Associates of the Guild
-
-Members of the University Senate
-
-Members of the University Staff
-
-Students enrolled at the University of Western Australia.
-
-**5. SUBSCRIPTIONS**
-
-5.1 The annual subscription for ordinary membership shall be an absolute minimum of \$4.
-
-5.2 Guild members shall receive a minimum $2 discount on yearly subscription fees and $1 on half-year subscription fees.
+3.6 Any member may leave the club or resign from a particular post they hold, at any time, by providing written notice to the secretary.
 
 **6. HONORARY LIFE MEMBERS**
 
-6.1 The Club may in General Meeting by two-thirds majority of those present and voting confer Honorary Life Membership upon any member who has performed outstanding service to the Club.
+6.1 The Club may in General Meeting by two-thirds majority of those present and voting confer Honorary Life Membership upon any member who has performed outstanding service to the Club. Honorary Life Members are given the rights and privileges of an Associate of the Club, unless otherwise eligible to be an Ordinary Member.
 
 **7. PRIMACY OF ORDINARY MEMBERS**
 
-7.1 Members other than Ordinary Members shall not:
+7.1 Only Members that are Ordinary Members shall:
 
 Be voting members of the Club.
 
@@ -74,15 +52,14 @@ Nominate candidates for the offices and Committee of the Club.
 
 Become or remain office bearers of the Club.
 
-But shall otherwise have all the rights and privileges of ordinary membership.
-
 **8. MEETING OF THE CLUB**
 
-8.1 The Club shall hold its Annual General Meeting in March of each academic year. There shall be one Ordinary General Meeting(s) of the club in each academic semester.
+8.1 The Club shall hold its Annual General Meeting in March of each academic year.
 
 8.1.1 The Club will hold its inaugural Annual General Meeting in August.
 
 8.2 The Committee may at any time call a Special General Meeting of the Club.
+
 8.3 The Secretary shall forthwith call a Special General Meeting upon receiving a written requisition from at least 10 financial ordinary members of the Club, and such a meeting shall be held no later than ten days immediately following receipt of such a requisition.
 
 8.4 If the Secretary fails to call the meeting within that time, any of the signatories of the requisition may do so. Any business set out in the requisition shall have priority over all the other business.
@@ -109,15 +86,9 @@ But shall otherwise have all the rights and privileges of ordinary membership.
 
 10.1 The Club may, at the Annual General Meeting, elect a patron who shall, if they indicate their willingness to do so, hold office until the succeeding Annual General Meeting; nominations shall close at that meeting.
 
-**11. NOMINATIONS**
-
-11.1 At least seven days before the Annual General Meeting, the Secretary shall call for nominations for the Executive Office Bearers and Committee of the Club. Nominations shall close at the commencement of that meeting or earlier if stated in the notice.
-
-11.2 Included in the same notice shall be details of the Annual General Meeting.
-
 **12. EXECUTIVE OFFICE BEARERS**
 
-12.1 The Executive Office Bearers of the Club shall be elected by the Ordinary Members of the Club at the Annual General Meeting and shall consist of, in order of seniority:
+12.1 The Executive Office Bearers of the Club shall consist of, in order of seniority:
 
 The President
 
@@ -129,19 +100,9 @@ The Secretary
 
 The Treasurer
 
-12.2 These members will be representatives of the appropriate Guild Sub-council(s) and Guild Meetings.
+12.2 No Executive Office Bearer may hold an Executive position simultaneously within the club or with another University of WA Club. In the event it does happen, The Executive Office Bearer must step down from their Executive Position in any of Clubs.
 
-12.3 Only financial Ordinary Members of the Club who are also members of the Guild shall be eligible for election as Executive Office Bearers.
-
-12.4 Election shall be conducted by optional preferential ballot for each office in the order shown above.
-
-12.5 A Candidate defeated for one office may stand for any office lower on the list.
-
-12.6 The powers and duties of Executive Office Bearers are defined in Articles 21-24.
-
-12.7 No Executive Office Bearer may hold an Executive position simultaneously within the club or with another University of WA Club. In the event it does happen, The Executive Office Bearer must step down from his/her Executive Position in any of Clubs.
-
-12.8 The Committee in meeting may dismiss an Elected Office-Bearer where, in the opinion of three quarters of the members of the Committee present and voting, that Elected Office-Bearer has:
+12.3 The Committee in meeting may dismiss an Elected Office-Bearer where, in the opinion of three quarters of the members of the Committee present and voting, that Elected Office-Bearer has:
 
 (a) Consistently failed adequately to discharge the duties of that position; or
 
@@ -155,75 +116,115 @@ The Treasurer
 
 13.1 The Committee of the Club shall only consist of:
 
-(a) The Executive Office Bearers;
+1. The President
 
-(b) The Ordinary Committee who shall consist of:
+2. The Vice-President
 
-1 Marketing Officer
+3. The Technical Lead
 
-6 Ordinary Committee Members
+4. The Secretary
 
-1 Fresher Representative
+5. The Treasurer
 
-and be elected by the financial Ordinary Members of the Club by optional preferential ballot of the Annual General Meeting subsequent to the election of Office Bearers.
+6. The Marketing Officer
 
-(c) The Immediate Past President.
+7. A minimum of six and a maximum of eight Ordinary Committee Members
 
-Only the person who held the Elected Office Bearer position of President immediately preceding the commencement of the current President‘s term shall be appointed Immediate Past President.
+8. The Fresher Representative
 
-**14. DURATION OF OFFICE**
+9. The Immediate Past President.
 
-14.1 The Executive Office Bearers and the Ordinary Committee members shall remain in office until the next Annual General Meeting.
+13.2 Only the person who held the Elected Office Bearer position of President immediately preceding the commencement of the current President‘s term shall be appointed Immediate Past President.
 
-14.2 If an Ordinary Committee Member fails to arrive to a meeting without a valid reason, they shall gain a strike. If the same member gains three strikes, they shall be removed from the position.
+**. ELECTION**
 
-14.3 If an Ordinary Committee Member fails to fulfil their role, they shall be subject to the same rules as that of an Executive Office Bearer outlined in Article 12.8 of this Constitution.
+14.1 The Club shall hold its Annual General Meeting in March of each academic year.
 
-**15. VACANCIES**
+14.2 The following members of the Committee shall be elected at the Annual General Meeting:
 
-15.1 If an Office Bearer resigns or ceases to hold office for any reason the remaining members of the Committee shall forthwith fill the vacancy so created by appointing thereto a member of the Committee from the Ordinary Membership, subject to review at the next General Meeting.
+1. The President
 
-15.2 The committee shall therefore have the power to appoint a financial member of the club as an interim Ordinary Committee Member to fill the vacancy.
+2. The Vice President
 
-15.3 Newly appointed Office Bearers will be ratified at the next General Meeting of the club, which shall be held no later than 2 months after the appointment/s.
+3. The Technical Lead
 
-**16. COMMITTEE MEETINGS**
+4. The Secretary
 
-16.1 The Committee shall meet at such times and places as the President shall determine.
+5. The Treasurer
 
-16.2 The Secretary shall cause all members of the Committee to receive seven days’ notice before the date fixed for the meeting together with an agenda of the business to be discussed.
+6. The Marketing Officer
 
-16.3 The Secretary shall forthwith call a Special General Meeting of the Committee upon receiving a written requisition from at least two members thereof, and such a Special General Meeting shall be held not later than seven days immediately following receipt of requisition.
+7. Six Ordinary Committee Members
 
-16.4 If the Secretary fails to call the meeting within that time, any one of the members signing the requisition may do so. Any business set out in the requisition shall have priority over all other business.
+8. The Fresher Representative
 
-**17. QUORUM AND PROCEDURE OF COMMITTEE**
+14.3 The Secretary shall call for nominations for the above positions at least seven days before the date of the Annual General Meeting. The nominations shall close at that meeting.
 
-17.1 The quorum of the Committee shall be 5 of whom at least two shall be Office Bearers.
+14.4 Any Ordinary Member of the Club may vote for the positions of Committee members.
 
-17.2 All meetings of the Committee shall be conducted in accordance with the procedure prescribed in the Standing Rules and Orders of the Guild Council.
+14.5 Only Ordinary Members of the Club who are students at The University of Western Australia and members of the Student Guild of The University of Western Australia may hold positions on the Committee.
 
-**18. POWER OF COMMITTEE**
+14.6 Members may be elected to and hold at most one position on the Committee.
+
+14.7 The committee may choose to hold an Ordinary General Meeting in the second academic semester.
+
+14.7.1 At this Ordinary General Meeting, the committee may hold an election for up to two additional Ordinary Committee Members
+
+14.7.2 The decision to hold such an election will be decided by, and announced by, the committee, at least ten days before the date of the Ordinary General Meeting.
+
+**15. DURATION OF OFFICE**
+
+15.1 The Executive Office Bearers and the Ordinary Committee members shall remain in office until the next Annual General Meeting.
+
+15.2 If an Ordinary Committee Member fails to arrive to a meeting without a valid reason, they shall gain a strike. If the same member gains three strikes, they shall be removed from the position.
+
+15.3 If an Ordinary Committee Member fails to fulfil their role, they shall be subject to the same rules as that of an Executive Office Bearer outlined in Article 12.8 of this Constitution.
+
+**16. VACANCIES**
+
+16.1 If an Office Bearer resigns or ceases to hold office for any reason the remaining members of the Committee shall forthwith fill the vacancy so created by appointing thereto a member of the Committee from the Ordinary Membership, subject to review at the next General Meeting.
+
+16.2 The committee shall therefore have the power to appoint a financial member of the club as an interim Ordinary Committee Member to fill the vacancy.
+
+16.3 Newly appointed Office Bearers will be ratified at the next General Meeting of the club, which shall be held no later than 2 months after the appointment/s.
+
+**17. COMMITTEE MEETINGS**
+
+17.1 The Committee shall meet at such times and places as the President shall determine.
+
+17.2 The Secretary shall cause all members of the Committee to receive seven days’ notice before the date fixed for the meeting together with an agenda of the business to be discussed.
+
+17.3 The Secretary shall forthwith call a Special General Meeting of the Committee upon receiving a written requisition from at least two members thereof, and such a Special General Meeting shall be held not later than seven days immediately following receipt of requisition.
+
+17.4 If the Secretary fails to call the meeting within that time, any one of the members signing the requisition may do so. Any business set out in the requisition shall have priority over all other business.
+
+**18. QUORUM AND PROCEDURE OF COMMITTEE**
+
+18.1 The quorum of the Committee shall be 5 of whom at least two shall be Office Bearers.
+
+18.2 All meetings of the Committee shall be conducted in accordance with the procedure prescribed in the Standing Rules and Orders of the Guild Council.
+
+**19. POWER OF COMMITTEE**
 
 Subject to this Constitution, the Committee shall be responsible to the Club in General Meeting for giving effect to the Objectives of the Club as set out in Article 2 and elsewhere in this Constitution and for carrying on its everyday business, and without prejudice to the generality of the foregoing, have the power to:
 
-18.1 Acquire and dispose of property; dispose of monies; open banking accounts; and enter into contracts. Unless acting under a special enabling resolution of General Meeting, however, the Committee shall not borrow or raise money or incur debts or liabilities on behalf of or in the name of the Club to a greater amount than five dollars for each and every then existing financial Ordinary Member of the Club.
+19.1 Acquire and dispose of property; dispose of monies; open banking accounts; and enter into contracts. Unless acting under a special enabling resolution of General Meeting, however, the Committee shall not borrow or raise money or incur debts or liabilities on behalf of or in the name of the Club to a greater amount than five dollars for each and every then existing financial Ordinary Member of the Club.
 
-18.2 Make regulations for the orderly and proper management of the affairs of the Club, ensuring that no regulation is inconsistent or repugnant with this Constitution.
+19.2 Make regulations for the orderly and proper management of the affairs of the Club, ensuring that no regulation is inconsistent or repugnant with this Constitution.
 
-18.3 Make, alter or repeal By-Laws and impose fines for the breach therefore. All By-Laws and any alterations or amendment therefore shall be subject to ratification by Societies Council and Guild Council before coming into force. The maximum fine imposed may not exceed five dollars.
+19.3 Make, alter or repeal By-Laws and impose fines for the breach therefore. All By-Laws and any alterations or amendment therefore shall be subject to ratification by Societies Council and Guild Council before coming into force. The maximum fine imposed may not exceed five dollars.
 
-**19. CHAIR**
+**20. CHAIR**
 
-19.1 The President shall have the right to take the Chair at any meeting of the Club or of the Committee.
+20.1 The President shall have the right to take the Chair at any meeting of the Club or of the Committee.
 
-19.2 If the President is absent or does not wish to exercise his right at any meeting, that right shall develop upon the Vice President.
+20.2 If the President is absent or does not wish to exercise his right at any meeting, that right shall develop upon the Vice President.
 
-19.3 In the event of absence of both the President and the Vice President, or in event of them both not wishing to exercise their right, that meeting shall elect its own Chair.
+20.3 In the event of absence of both the President and the Vice President, or in event of them both not wishing to exercise their right, that meeting shall elect its own Chair.
 
-**20. PRESIDENT**
+**21. PRESIDENT**
 
-20.1 In addition to any provisions set out elsewhere in this Constitution or in any By-Laws or Regulations made hereunder, it shall be the duty of the President to:
+21.1 In addition to any provisions set out elsewhere in this Constitution or in any By-Laws or Regulations made hereunder, it shall be the duty of the President to:
 
 (a) Coordinate and supervise the work of the Executive Office Bearers, subject to the authority of the Club in General Meeting.
 
@@ -233,16 +234,17 @@ Subject to this Constitution, the Committee shall be responsible to the Club in 
 
 (d) Report on the status of the club to the ordinary members at all general meetings.
 
-**21. VICE PRESIDENT**
+**22. VICE PRESIDENT**
 
-21.1 In addition to any provisions set out elsewhere in the Constitution or in any By-Laws or Regulations made hereunder, it shall be the duty of the Vice President to:
+22.1 In addition to any provisions set out elsewhere in the Constitution or in any By-Laws or Regulations made hereunder, it shall be the duty of the Vice President to:
 
 (a) Seek, engage and maintain client relationships, as well as source projects, and oversee their delivery.
+
 (b) assist the President wherever possible.
 
-**22. TECHNICAL LEAD**
+**23. TECHNICAL LEAD**
 
-22.1 In addition to any provisions set out elsewhere in the Constitution or in any By-Laws or Regulations made hereunder, it shall be the duty of the Technical Lead:
+23.1 In addition to any provisions set out elsewhere in the Constitution or in any By-Laws or Regulations made hereunder, it shall be the duty of the Technical Lead:
 
 (a) To advise the Committee on technical and development related matters.
 
@@ -250,9 +252,9 @@ Subject to this Constitution, the Committee shall be responsible to the Club in 
 
 (c) To conduct code reviews and assist with project development if requested.
 
-**23. SECRETARY**
+**24. SECRETARY**
 
-23.1 In addition to any provisions set out elsewhere in the Constitution or in any By-Laws or Regulations made hereunder, it shall be the duty of the Secretary:
+24.1 In addition to any provisions set out elsewhere in the Constitution or in any By-Laws or Regulations made hereunder, it shall be the duty of the Secretary:
 
 (a) To record all proceedings of the Club and the Committee in a Club Minute Book which they shall cause to be provided for that purpose:
 
@@ -270,9 +272,9 @@ To lodge with the Secretary of the Societies Council a copy of the Constitution 
 
 (e) In the event of the Club being de-registered, to present to the Societies Council Secretary within thirty days a duly audited statement of the financial position of the Club together with a copy of the resolution, which may have been passed by the Club as to the disposition of its funds.
 
-**24. TREASURER**
+**25. TREASURER**
 
-24.1 In addition to any provisions set out elsewhere in the Constitution or in any By-Laws or Regulations made hereunder, it shall be the duty of the Treasurer:
+25.1 In addition to any provisions set out elsewhere in the Constitution or in any By-Laws or Regulations made hereunder, it shall be the duty of the Treasurer:
 
 Keep proper books of account dealing with the property and finances of the Club and to furnish the Committee with such accounts and information relating to the finances and property of the Club as the Committee from time to time require.
 
@@ -284,52 +286,52 @@ Produce and deliver all necessary books, vouchers and other documents to the per
 
 Prepare necessary forms, and receipts for Societies Council in accordance with Societies Council grant policies.
 
-**25. DEPOSITS AND WITHDRAWAL OF MONIES**
+**26. DEPOSITS AND WITHDRAWAL OF MONIES**
 
-25.1 All monies due and payable to the Club shall be received by the Treasurer who shall lodge them without undue delay with Guild Finance for the credit of the Club.
+26.1 All monies due and payable to the Club shall be received by the Treasurer who shall lodge them without undue delay with Guild Finance for the credit of the Club.
 
-25.2 Any two members of the Executive may jointly sign cheques and forms of authority for the payment of funds of the Society.
+26.2 Any two members of the Executive may jointly sign cheques and forms of authority for the payment of funds of the Society.
 
-25.3 Notwithstanding anything contained herein, no persons shall deposit or withdraw any monies into any account that Guild Council has closed by resolution.
+26.3 Notwithstanding anything contained herein, no persons shall deposit or withdraw any monies into any account that Guild Council has closed by resolution.
 
-**26. PAYMENTS**
+**27. PAYMENTS**
 
-26.1 No payments shall be made on behalf or in the name of the Club unless it has been authorised by the Executive Office Bearers, in accordance with Article 2.2
+27.1 No payments shall be made on behalf or in the name of the Club unless it has been authorised by the Executive Office Bearers, in accordance with Article 2.2
 
-**27. MAJOR OBLIGATIONS TO GUILD**
+**28. MAJOR OBLIGATIONS TO GUILD**
 
-27.1 The Club shall comply with the Regulation of the Guild, the Rules of the Societies Council, and all other provisions enrolled upon the Guild Statutes book.
+28.1 The Club shall comply with the Regulation of the Guild, the Rules of the Societies Council, and all other provisions enrolled upon the Guild Statutes book.
 
-27.2 All Office Bearers and committee members shall be jointly and severally responsible for such compliance, and shall be deemed liable in the event of noncompliance therewith.
+28.2 All Office Bearers and committee members shall be jointly and severally responsible for such compliance, and shall be deemed liable in the event of noncompliance therewith.
 
-**28. EXPULSION OF MEMBERS**
+**29. EXPULSION OF MEMBERS**
 
-28.1 The Committee may by unanimous vote request any member or associate member to resign from the Club, and in the event shall cause written notification of such request to be served upon the member concerned.
+29.1 The Committee may by unanimous vote request any member or associate member to resign from the Club, and in the event shall cause written notification of such request to be served upon the member concerned.
 
-28.2 Should such a request prove ineffectual after fourteen days of written notification, the Committee may serve written notice of intended expulsion of the member concerned and should they not have resigned seven days after, the Committee may by unanimous vote expel him or her from the Club; but such expulsion shall be subject to review at the next General Meeting with the member present and to be heard.
+29.2 Should such a request prove ineffectual after fourteen days of written notification, the Committee may serve written notice of intended expulsion of the member concerned and should they not have resigned seven days after, the Committee may by unanimous vote expel him or her from the Club; but such expulsion shall be subject to review at the next General Meeting with the member present and to be heard.
 
-28.3 A person who has been expelled or has resigned their membership may not reapply for membership for the period of one year.
+29.3 A person who has been expelled or has resigned their membership may not reapply for membership for the period of one year.
 
-**29. AVAILABILITY OF CONSTITUTION**
+**30. AVAILABILITY OF CONSTITUTION**
 
-29.1 The Committee shall make this Constitution available on request to all Ordinary Members.
+30.1 The Committee shall make this Constitution available on request to all Ordinary Members.
 
-**30. INTERPRETATION**
+**31. INTERPRETATION**
 
-30.1 Subject to any provisions enrolled upon the Guild Statutes book and to any resolution passed by Guild Council, or the Societies Council, the President shall have the power to interpret the meaning of any of the provisions contained in the Constitution, but the determining decision in case of doubt shall rest with the Club in General Meeting.
+31.1 Subject to any provisions enrolled upon the Guild Statutes book and to any resolution passed by Guild Council, or the Societies Council, the President shall have the power to interpret the meaning of any of the provisions contained in the Constitution, but the determining decision in case of doubt shall rest with the Club in General Meeting.
 
-**31. AMENDMENT OF THIS CONSTITUTION**
+**32. AMENDMENT OF THIS CONSTITUTION**
 
-31.1 Any two financial Ordinary Members of the Club may not less than three days before the day appointed for the next General Meeting submit to the Secretary a notice of motion signed by them proposing an alteration to this Constitution. This shall be posted on notice boards forthwith.
+32.1 Any two financial Ordinary Members of the Club may not less than three days before the day appointed for the next General Meeting submit to the Secretary a notice of motion signed by them proposing an alteration to this Constitution. This shall be posted on notice boards forthwith.
 
-31.2 The motion may then be considered by the Club at its next meeting and amendments that are relevant to the subject matter thereof may be moved without notice.
+32.2 The motion may then be considered by the Club at its next meeting and amendments that are relevant to the subject matter thereof may be moved without notice.
 
-31.3 The motion of any amendment thereto shall not be deemed adopted unless it receives a two-thirds majority of the members present and voting.
+32.3 The motion of any amendment thereto shall not be deemed adopted unless it receives a two-thirds majority of the members present and voting.
 
-31.4 The motion as adopted with any amendments shall come into force upon receiving the approval of the Societies Council.
+32.4 The motion as adopted with any amendments shall come into force upon receiving the approval of the Societies Council.
 
-**32. DISSOLUTION OF THE CLUB**
+**33. DISSOLUTION OF THE CLUB**
 
-32.1 If upon the dissolution of the club, any property of the club remains after satisfaction of the debts and liabilities of the club that property shall be distributed to another association or club affiliated to the Societies Council which has similar objectives to those of the club, and which association shall be determined by resolution of the members.
+33.1 If upon the dissolution of the club, any property of the club remains after satisfaction of the debts and liabilities of the club that property shall be distributed to another association or club affiliated to the Societies Council which has similar objectives to those of the club, and which association shall be determined by resolution of the members.
 
-Adopted by General Meeting - 20/03/2024
+Adopted by General Meeting - 12/09/2025

--- a/Constitution.md
+++ b/Constitution.md
@@ -178,7 +178,7 @@ _.7.2 The decision to hold such an election will be decided by, and announced by
 
 14.2 If an Ordinary Committee Member fails to arrive to a meeting without a valid reason, they shall gain a strike. If the same member gains three strikes, they shall be removed from the position.
 
-14.3 If an Ordinary Committee Member fails to fulfil their role, they shall be subject to the same rules as that of an Executive Office Bearer outlined in Article 12.8 of this Constitution.
+14.3 If an Ordinary Committee Member fails to fulfil their role, they shall be subject to the same rules as that of an Executive Office Bearer outlined in Article 12.3 of this Constitution.
 
 **15. VACANCIES**
 

--- a/Constitution.md
+++ b/Constitution.md
@@ -26,7 +26,7 @@ To do all such things as would appear necessary and proper for the benefit or ad
 
 3.2 A subscription for an Ordinary Membership may be made payable to the Club if the Committee so desires.
 
-3.2.1 A subscription for an Ordinary Membership may only be bought by an enrolled Student of the University of Western Australia and a current member of the University of Western Australia Student Guild.
+3.2.1 A subscription for an Ordinary Membership may only be bought by a person who is an enrolled Student of the University of Western Australia and is a current member of the University of Western Australia Student Guild.
 
 3.3 A subscription for an Associate Membership may be made payable to the Club if the Committee so desires.
 
@@ -102,7 +102,7 @@ The Treasurer
 
 12.2 No Executive Office Bearer may hold an Executive position simultaneously within the club or with another University of WA Club. In the event it does happen, The Executive Office Bearer must step down from their Executive Position in any of Clubs.
 
-12.3The Committee in meeting may dismiss an Elected Office-Bearer where, in the opinion of three quarters of the members of the Committee present and voting, that Elected Office-Bearer has:
+12.3 The Committee in meeting may dismiss an Elected Office-Bearer where, in the opinion of three quarters of the members of the Committee present and voting, that Elected Office-Bearer has:
 
 (a) Consistently failed adequately to discharge the duties of that position; or
 
@@ -256,7 +256,7 @@ Subject to this Constitution, the Committee shall be responsible to the Club in 
 
 23.1 In addition to any provisions set out elsewhere in the Constitution or in any By-Laws or Regulations made hereunder, it shall be the duty of the Secretary:
 
-(a) To record all proceedings of the Club and the Committee in a Club Minute Book which they shall cause to be provided for that purpose:
+(a) To record the proceedings of all General Meetings and meetings of the Committee and make these minutes available in an easily accessible portion of the Club's online presence.
 
 (b) To conduct and keep copies of all correspondence of the Club:
 


### PR DESCRIPTION
Proposed amendments to the constitution for the September 2025 SGM.
Changes include:
- Allow a minimum of 6 and a maximum of 8 OCMs on committee
- Allow the club to hold an OGM in semester 2 where the committee can choose to elect up to two new OCMs
- Removes clauses specifying voting method
- Adds detail and clarification to the membership section - allows members to contact the secretary to relinquish their membership if they so wish
- Ordinary members may now only be UWA students
- Associate members may now be any member of the public
- Adds new "Elections" section for election information
- Mandates that meeting minutes should be easily accessible online

**Please note: Section and clause numbers have not been changed in order to make the diff easier to read. They will be changed after motions have been passed, before the changes have been merged in.**